### PR TITLE
22 april2024

### DIFF
--- a/GUI/addqualityflag.m
+++ b/GUI/addqualityflag.m
@@ -131,11 +131,7 @@ switch qualflag
             end
         else
             ptemp=pd.qc;
-            gg=strfind(ptemp','5');
-            if(isempty(gg))
-                gg=0;
-            end
-            startpoint=gg(end)+1;
+            startpoint=1;
             endpoint=pd.ndep;
         end
         
@@ -144,7 +140,6 @@ switch qualflag
         histd=pd.depth(startpoint);
         actparm='TEMP';
         oldt='99.99';
-        severity=5;
         addhistories
         handles.pd=pd;
         

--- a/GUI/addqualityflag.m
+++ b/GUI/addqualityflag.m
@@ -37,7 +37,7 @@ update = datestr(now,'yyyymmdd');
 switch qualflag
     
     case 'CSA'
-        
+
         if(strmatch('XC',handles.keys.datatype(handles.currentprofile,:)))
             kk=find(pd.depth<=1.9);
         else
@@ -144,7 +144,7 @@ switch qualflag
         histd=pd.depth(startpoint);
         actparm='TEMP';
         oldt='99.99';
-        severity=2;
+        severity=5;
         addhistories
         handles.pd=pd;
         
@@ -365,8 +365,8 @@ switch qualflag
             actparm='TIME';
             addhistories
             %you must also change the keys file!!!
-            
-            keysdata.time(handles.currentprofile)=newtime;
+            % HHMM format for keys
+            keysdata.time(handles.currentprofile)=str2num(keytime(1:4));
             
             handles.pd=pd;
             handles.keys=keysdata;

--- a/GUI/getkeystroke.m
+++ b/GUI/getkeystroke.m
@@ -147,7 +147,7 @@ qcstring= [pd.QC_code(kk,:) num2str(pd.QC_depth(kk),' \t%9.2f')];
         updatekeys('obs_d',keysdata.masterrecno(handles.currentprofile),...
                 pd.day,keysdata.prefix);
         updatekeys('obs_t',keysdata.masterrecno(handles.currentprofile),...
-                t,keysdata.prefix);
+                t(1:4),keysdata.prefix);
         updatekeys('obslat',keysdata.masterrecno(handles.currentprofile),...
                 pd.latitude,keysdata.prefix);
        
@@ -161,7 +161,7 @@ qcstring= [pd.QC_code(kk,:) num2str(pd.QC_depth(kk),' \t%9.2f')];
         keysdata.year(handles.currentprofile)=str2num(pd.year);
         keysdata.month(handles.currentprofile)=str2num(pd.month);
         keysdata.day(handles.currentprofile)=str2num(pd.day);
-        keysdata.time(handles.currentprofile)=str2num(t);
+        keysdata.time(handles.currentprofile)=str2num(t(1:4));
         keysdata.obslon(handles.currentprofile)=c;
         keysdata.obslat(handles.currentprofile)=pd.latitude;
         

--- a/GUI/interpolatespikes.m
+++ b/GUI/interpolatespikes.m
@@ -33,7 +33,7 @@ for i=nn+1:nn+abs(startpoint-endpoint)+1
     pd.QC_depth(i)=pd.depth(cind);
     pd.PRC_Date(i,1:8)=update;
     pd.PRC_Code(i,1:4)='CSCB';
-    pd.Version(i,1:4)=' 1.0';
+    pd.Version(i,1:4)=' 2.0';
     pd.Act_Parm(i,1:4)='TEMP';
     oldt=num2str(pd.temp(cind));
     pd.Previous_Val(i,1:length(oldt))=oldt;
@@ -53,7 +53,7 @@ if(isfield(pd,'sal'))
         pd.QC_depth(i)=pd.depthsal(cind);
         pd.PRC_Date(i,1:8)=update;
         pd.PRC_Code(i,1:4)='CSCB';
-        pd.Version(i,1:4)=' 1.0';
+        pd.Version(i,1:4)=' 2.0';
         pd.Act_Parm(i,1:4)='PSAL';
         oldt=num2str(pd.sal(cind));
         pd.Previous_Val(i,1:length(oldt))=oldt;

--- a/GUI/medianfilter.m
+++ b/GUI/medianfilter.m
@@ -25,10 +25,13 @@ for kk=s1:s2
     if(~isempty(llk))
         temptemp(kk)=median(tt(llk));
     else
-%retain original value 
+        %retain original value
     end
 end
-
+%assign qc values to temp here as this is where the start and endpoints
+%exist
+pd.qc(s1:s2) = '5';
+pd.qc(s2+1:end) = '2';
 pd.temp=temptemp;
 handles.pd=pd;
 %saveguidata

--- a/GUI/new_plotbuddies.m
+++ b/GUI/new_plotbuddies.m
@@ -19,7 +19,7 @@ i=handles.currentprofile;
 keysdata=handles.keys;
 currentlat=keysdata.obslat(i);
 currentlon=keysdata.obslon(i);
-col=['gbyrg'];
+col=['gbyrb'];
 handles.displaybuddy='Y';   
 
 %saveguidata

--- a/GUI/plotbuddies.m
+++ b/GUI/plotbuddies.m
@@ -22,7 +22,7 @@ keysdata=handles.keys;
 currentlat=keysdata.obslat(i);
 currentlon=keysdata.obslon(i);
 currentmonth=keysdata.month(i);
-col=['gbyrg'];
+col=['gbyrb'];
 handles.displaybuddy='Y';   
 
 %saveguidata

--- a/GUI/plotprofile.m
+++ b/GUI/plotprofile.m
@@ -9,7 +9,7 @@ tt=title([ 'Database prefix: ' keysdata.prefix '(' num2str(length(keysdata.stnnu
 i=handles.currentprofile;
 currentp=i
 
-col=['gbyrg'];
+col=['gbyrb'];
 readnetcdf;
 pd = handles.pd;
 handles.changed='N';

--- a/GUI/printqflags.m
+++ b/GUI/printqflags.m
@@ -21,7 +21,7 @@ set(g,'LineWidth',2);
 
 
 
-col=['gbyrg'];
+col=['gbyrb'];
 
 %plot colored line of profile quality
 clear xc

--- a/GUI/re_plotprofile.m
+++ b/GUI/re_plotprofile.m
@@ -16,7 +16,7 @@ i=handles.currentprofile;
 ylimit=get(handles.profile,'Ylim');
 xlimit=get(handles.profile,'Xlim');
 
-col=['gbyrg'];
+col=['gbyrb'];
 % remove this because otherwise resetting from zoom leaves the zoomed
 % quality bar at the side - caution this might slow it down...
 %if(handles.displaybuddy~='Y')

--- a/GUI/zoomprofile.m
+++ b/GUI/zoomprofile.m
@@ -5,7 +5,7 @@
 
 i=handles.currentprofile;
 
-col=['gbyrg'];
+col=['gbyrb'];
 plot_clim;
 isn=find(~isnan(pd.temp) & pd.temp<99.);
 

--- a/TextFiles/questAflags.txt
+++ b/TextFiles/questAflags.txt
@@ -1,5 +1,4 @@
 QCA 1 0
-CSA 5 0
 CTA 1 0
 EFA 1 0
 FSA 2 0


### PR DESCRIPTION
Multiple updates including keys time fixes to HHMM from HHMMSS display. Fix bug where killing the profile with 'TE' flag was failing.
Also updated handling of the HFA, IPA, SPA flags to match the Cookbook V2.0/2.1 where interpolated parts are flagged with 5 and data deeper are 2.
Rewrite the assignment of quality values to temperature to tidy up and make it more robust.
Fixed the PLA flag handling where there are NaNs at the bottom of temperature profiles, the QC value is made equal to 0 for the matching depths.
Flag 5 is now visualised as blue in plots (same as flag 2).