### PR TITLE
Update xctd tick box handling on export and try to fix mky handling, …

### DIFF
--- a/GUI/exportdata.m
+++ b/GUI/exportdata.m
@@ -92,6 +92,9 @@ handles.keys2=keysdata2;
 % Choose default command line output for exportdata
 handles.output = -1;
 
+% default xctd extraction
+handles.usexctd = 1;
+
 % Update handles structure
 guidata(hObject, handles);
 
@@ -332,12 +335,12 @@ selectedcallsign=callslist(callsselected);
 
 subsetkeys=strmatch(selectedcallsign,keysdata2.callsign);
 %subset for XBTS if no XCTD selected (note, removes CTDs too).
-try
+% try
 if handles.usexctd == 0
     sk = strmatch('XB',keysdata2.datatype);
     subsetkeys = unique([subsetkeys;sk]);
 end
-end
+% end
 if(~isempty(subsetkeys))
     %create data structure:
     %for i=1:length(subsetkeys)

--- a/Util/fix_cruiseID.m
+++ b/Util/fix_cruiseID.m
@@ -33,17 +33,17 @@ end
 % note there is a correct 177N in April, 2022
 
 % fix first issue:
-ii = contains(crid, '176N') & ti < datenum(2022,3,1); 
-crid(ii) = {'176S      '};
+ii = matches(crid, 'IN2015_V02');% & ti < datenum(2022,3,1); 
+crid(ii) = {'in2015_v02'};
 
-% fix second issue:
-ij = contains(crid, '177N') & ti < datenum(2022,4,1); 
-crid(ij) = {'176N      '};
+% % fix second issue:
+% ij = contains(crid, '177N') & ti < datenum(2022,4,1); 
+% crid(ij) = {'176N      '};
 
 %%
 %write back to file:
-stns = [stnnum(ii); stnnum(ij)];
-crids = [crid(ii), crid(ij)];
+stns = stnnum(ii);%[stnnum(ii); stnnum(ij)];
+crids = crid(ii);%[crid(ii), crid(ij)];
 for aa=1:length(stns)
     for bb = 1:2
         raw= bb -1;

--- a/WriteRoutines/writeMA.m
+++ b/WriteRoutines/writeMA.m
@@ -4,7 +4,7 @@
 %retrieveguidata
 
 if i == 1
-    clear recwritten
+    recwritten = 0;
 end
 if(strmatch('TP',profiledata.Act_Code(:,:)'))
     return
@@ -24,7 +24,7 @@ if (fid==-1)
     return
 end
 
-if exist('recwritten','var') == 0 %for the sort key in MA files
+if recwritten == 0 %for the sort key in MA files
     mkstart = '00000100'
     profiledata.Mky = mkstart;
     mky = profiledata.Mky(1:6);


### PR DESCRIPTION
But the fix didn't actually fix the mky handling. Bypass by making the cruiseid's the same for the dataset I was working on. Need to be careful in future when exporting to MA.